### PR TITLE
Improve Slack handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,9 @@ as the Slack event request URL.
 
 The application is designed to be deployed to Cloud Run. Environment variables
 for `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET` and `GEMINI_API_KEY` must be
-provided.
+provided. The service will fail to start if any of these variables are missing.
+
+The `/healthz` route can be used for basic health checks and simply returns `OK`.
+
+The bot responds to direct messages and mentions. Incoming events are acknowledged
+immediately before calling Gemini to avoid Slack timeouts.

--- a/main.py
+++ b/main.py
@@ -4,9 +4,18 @@ from slack_bolt import App
 import google.generativeai as genai
 import os
 
-SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
-SLACK_SIGNING_SECRET = os.environ["SLACK_SIGNING_SECRET"]
-GEMINI_API_KEY = os.environ["GEMINI_API_KEY"]
+
+def require_env_var(name: str) -> str:
+    """Return the value of an environment variable or raise an error."""
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Environment variable {name} is required")
+    return value
+
+
+SLACK_BOT_TOKEN = require_env_var("SLACK_BOT_TOKEN")
+SLACK_SIGNING_SECRET = require_env_var("SLACK_SIGNING_SECRET")
+GEMINI_API_KEY = require_env_var("GEMINI_API_KEY")
 MODEL = "gemini-2.0-flash"
 
 slack_app = App(token=SLACK_BOT_TOKEN, signing_secret=SLACK_SIGNING_SECRET)
@@ -21,19 +30,31 @@ def get_gemini_response(user_msg):
     return response.text
 
 @slack_app.event("app_mention")
-def handle_app_mention(body, say):
-    user_msg = body["event"]["text"]
-    response = get_gemini_response(user_msg)
+def handle_app_mention(body, say, ack, logger):
+    """Respond when the bot is mentioned in a channel."""
+    ack()
+    user_msg = body["event"].get("text", "")
+    try:
+        response = get_gemini_response(user_msg)
+    except Exception as e:
+        logger.exception("Gemini API request failed")
+        response = "Lo siento, ocurrió un error al procesar tu mensaje."
     say(response)
 
 
 @slack_app.event("message")
-def handle_message_events(body, say, logger):
+def handle_message_events(body, say, ack, logger):
+    """Handle direct messages to the bot."""
+    ack()
     event = body.get("event", {})
     if event.get("channel_type") == "im" and "bot_id" not in event:
         logger.info(body)
         user_msg = event.get("text", "")
-        response = get_gemini_response(user_msg)
+        try:
+            response = get_gemini_response(user_msg)
+        except Exception:
+            logger.exception("Gemini API request failed")
+            response = "Lo siento, ocurrió un error al procesar tu mensaje."
         say(response)
 
 @app.route("/", methods=["POST"])
@@ -41,6 +62,11 @@ def slack_events():
     if request.json and "challenge" in request.json:
         return jsonify({"challenge": request.json["challenge"]})
     return handler.handle(request)
+
+
+@app.route("/healthz", methods=["GET"])
+def health_check():
+    return "OK", 200
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary
- handle Slack events with explicit ack to avoid timeouts
- catch Gemini API errors and respond gracefully
- document the new behavior in the README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6886b2845f0c832581a05e2b558a663b