### PR TITLE
Improve Gemini integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ pip install -r requirements.txt
 python main.py
 ```
 
+The requirements file installs the modern `google-genai` SDK, which this bot
+uses to call Gemini models.
+
 Expose the `/` route via a tunnel (e.g. `ngrok`) and configure the resulting URL
 as the Slack event request URL.
 
@@ -20,4 +23,12 @@ as the Slack event request URL.
 
 The application is designed to be deployed to Cloud Run. Environment variables
 for `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET` and `GEMINI_API_KEY` must be
-provided.
+provided. The service will fail to start if any of these variables are missing.
+
+The bot uses the `gemini-2.5-flash` model by default. You can change this by
+editing the `MODEL` constant in `main.py`.
+
+The `/healthz` route can be used for basic health checks and simply returns `OK`.
+
+The bot responds to direct messages and mentions. Incoming events are acknowledged
+immediately before calling Gemini to avoid Slack timeouts.

--- a/main.py
+++ b/main.py
@@ -1,39 +1,63 @@
 from flask import Flask, request, jsonify
 from slack_bolt.adapter.flask import SlackRequestHandler
 from slack_bolt import App
-import google.generativeai as genai
+from google import genai
+from google.genai.errors import APIError
 import os
 
-SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
-SLACK_SIGNING_SECRET = os.environ["SLACK_SIGNING_SECRET"]
-GEMINI_API_KEY = os.environ["GEMINI_API_KEY"]
-MODEL = "gemini-2.0-flash"
+
+def require_env_var(name: str) -> str:
+    """Return the value of an environment variable or raise an error."""
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Environment variable {name} is required")
+    return value
+
+
+SLACK_BOT_TOKEN = require_env_var("SLACK_BOT_TOKEN")
+SLACK_SIGNING_SECRET = require_env_var("SLACK_SIGNING_SECRET")
+GEMINI_API_KEY = require_env_var("GEMINI_API_KEY")
+MODEL = "gemini-2.5-flash"
 
 slack_app = App(token=SLACK_BOT_TOKEN, signing_secret=SLACK_SIGNING_SECRET)
 handler = SlackRequestHandler(slack_app)
 app = Flask(__name__)
 
-genai.configure(api_key=GEMINI_API_KEY)
+client = genai.Client(api_key=GEMINI_API_KEY)
 
-def get_gemini_response(user_msg):
-    model = genai.GenerativeModel(MODEL)
-    response = model.generate_content(user_msg)
+def get_gemini_response(user_msg: str) -> str:
+    response = client.models.generate_content(
+        model=MODEL,
+        contents=user_msg,
+    )
     return response.text
 
 @slack_app.event("app_mention")
-def handle_app_mention(body, say):
-    user_msg = body["event"]["text"]
-    response = get_gemini_response(user_msg)
+def handle_app_mention(body, say, ack, logger):
+    """Respond when the bot is mentioned in a channel."""
+    ack()
+    user_msg = body["event"].get("text", "")
+    try:
+        response = get_gemini_response(user_msg)
+    except APIError:
+        logger.exception("Gemini API request failed")
+        response = "Lo siento, ocurrió un error al procesar tu mensaje."
     say(response)
 
 
 @slack_app.event("message")
-def handle_message_events(body, say, logger):
+def handle_message_events(body, say, ack, logger):
+    """Handle direct messages to the bot."""
+    ack()
     event = body.get("event", {})
     if event.get("channel_type") == "im" and "bot_id" not in event:
         logger.info(body)
         user_msg = event.get("text", "")
-        response = get_gemini_response(user_msg)
+        try:
+            response = get_gemini_response(user_msg)
+        except APIError:
+            logger.exception("Gemini API request failed")
+            response = "Lo siento, ocurrió un error al procesar tu mensaje."
         say(response)
 
 @app.route("/", methods=["POST"])
@@ -41,6 +65,11 @@ def slack_events():
     if request.json and "challenge" in request.json:
         return jsonify({"challenge": request.json["challenge"]})
     return handler.handle(request)
+
+
+@app.route("/healthz", methods=["GET"])
+def health_check():
+    return "OK", 200
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8080)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 slack_bolt
-google-generativeai
+google-genai
 gunicorn


### PR DESCRIPTION
## Summary
- use the new `google-genai` SDK instead of the deprecated package
- configure the Gemini client and default to `gemini-2.5-flash`
- document the new dependency and default model

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6886b2845f0c832581a05e2b558a663b