### PR TITLE
Integrate Gemini AI into Slack bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # People Virtual Agent
 
-This project implements a simple Slack bot using Flask and Bolt for Python. The bot replies with `hello world` when you mention it or send a direct message.
+This project implements a Slack bot using Flask and Bolt for Python. The bot connects to the Gemini API to generate responses when you mention it or send a direct message.
 
 ## Local testing
 
@@ -11,10 +11,15 @@ pip install -r requirements.txt
 python main.py
 ```
 
+Set the environment variables `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, and
+`GEMINI_API_KEY` before running the application.
+
 Expose the `/` route via a tunnel (e.g. `ngrok`) and configure the resulting URL as the Slack event request URL.
 
 ## Deployment
 
-The application is designed to be deployed to Cloud Run. Environment variables for `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` must be provided. The service will fail to start if any of these variables are missing.
+The application is designed to be deployed to Cloud Run. Environment variables
+for `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, and `GEMINI_API_KEY` must be
+provided. The service will fail to start if any of these variables are missing.
 
 The `/healthz` route can be used for basic health checks and simply returns `OK`.

--- a/gemini_AI.py
+++ b/gemini_AI.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Utilities for interacting with the Gemini API."""
+
+import os
+from typing import Dict
+
+from google import genai
+
+
+_client: genai.Client | None = None
+_chats: Dict[str, genai.Chat] = {}
+
+
+def _require_client() -> genai.Client:
+    """Return a singleton genai.Client instance."""
+    global _client
+    if _client is None:
+        if not os.getenv("GEMINI_API_KEY"):
+            raise RuntimeError("Environment variable GEMINI_API_KEY is required")
+        # The client automatically picks up GEMINI_API_KEY from the environment.
+        _client = genai.Client()
+    return _client
+
+
+def _get_chat(channel_id: str) -> genai.Chat:
+    """Return a chat session for the given channel."""
+    if channel_id not in _chats:
+        client = _require_client()
+        model_name = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
+        _chats[channel_id] = client.chats.create(model=model_name)
+    return _chats[channel_id]
+
+
+def send_message(channel_id: str, message: str) -> str:
+    """Send a message to Gemini and return the response text."""
+    chat = _get_chat(channel_id)
+    response = chat.send_message(message)
+    return response.text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 slack_bolt
 gunicorn
+google-genai

--- a/slack_bot.py
+++ b/slack_bot.py
@@ -1,8 +1,10 @@
-"""Slack bot that responds with 'hello world'."""
+"""Slack bot that interfaces with Gemini."""
 
 import os
 from slack_bolt import App
 from slack_bolt.adapter.flask import SlackRequestHandler
+
+import gemini_AI
 
 
 def require_env_var(name: str) -> str:
@@ -24,7 +26,11 @@ handler = SlackRequestHandler(slack_app)
 def handle_app_mention(body, say, ack):
     """Respond when the bot is mentioned in a channel."""
     ack()
-    say("hello world")
+    event = body.get("event", {})
+    channel_id = event.get("channel")
+    text = event.get("text", "")
+    response = gemini_AI.send_message(channel_id, text)
+    say(response)
 
 
 @slack_app.event("message")
@@ -33,5 +39,8 @@ def handle_message_events(body, say, ack):
     ack()
     event = body.get("event", {})
     if event.get("channel_type") == "im" and "bot_id" not in event:
-        say("hello world")
+        channel_id = event.get("channel")
+        text = event.get("text", "")
+        response = gemini_AI.send_message(channel_id, text)
+        say(response)
 


### PR DESCRIPTION
## Summary
- add a `gemini_AI` helper for communicating with Gemini
- update Slack bot to use Gemini for replies
- document Gemini setup and environment variables
- include `google-genai` in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886bf3acb488325afc83a2f5a924bcd