### PR TITLE
Migrate to google-genai and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project implements a Slack bot using Flask and Bolt for Python. The bot uses Google's Gemini API to generate responses when you mention it or send a direct message.
 
-> **Note**: The current implementation depends on the `google-generativeai` package. Google recommends using the new `google-genai` library for all Gemini API calls. See the [official code generation guidelines](https://github.com/googleapis/python-genai/blob/main/codegen_instructions.md) for up‑to‑date usage examples.
+> **Note**: This project now uses the `google-genai` library for Gemini API calls. See the [official code generation guidelines](https://github.com/googleapis/python-genai/blob/main/codegen_instructions.md) for up‑to‑date usage examples.
 
 ## Local testing
 

--- a/main.py
+++ b/main.py
@@ -4,12 +4,14 @@ from slack_sdk.errors import SlackApiError
 from dotenv import load_dotenv
 import os
 from threading import Thread
-import google.generativeai as genai
+import google.genai as genai
 
 # Carga variables de entorno
 load_dotenv()
 
 slack_token = os.getenv('SLACK_BOT_TOKEN')
+if not slack_token:
+    raise RuntimeError('SLACK_BOT_TOKEN is not set')
 client = WebClient(token=slack_token)
 BOT_USER_ID = os.getenv('BOT_USER_ID')
 if not BOT_USER_ID:
@@ -20,8 +22,10 @@ if not BOT_USER_ID:
         print(f"Failed to fetch bot user ID: {e.response['error']}")
 
 google_api_key = os.getenv('GEMINI_API_KEY')
-genai.configure(api_key=google_api_key)
-model = genai.GenerativeModel('gemini-2.0-flash')
+if not google_api_key:
+    raise RuntimeError('GEMINI_API_KEY is not set')
+model_name = os.getenv('GEMINI_MODEL', 'gemini-2.0-flash')
+genai_client = genai.Client(api_key=google_api_key)
 
 app = Flask(__name__)
 
@@ -65,7 +69,10 @@ def handle_event(data):
     if event_type == "message" and subtype is None:
         if event["channel"].startswith('D') or event.get("channel_type") == 'im' or event.get("channel_type") == "app_home":
             try:
-                gemini = model.generate_content(event["text"])
+                gemini = genai_client.models.generate_content(
+                    model=model_name,
+                    contents=event["text"],
+                )
                 textout = gemini.text.replace("**", "*")
                 response = client.chat_postMessage(
                     channel=event["channel"],
@@ -76,13 +83,20 @@ def handle_event(data):
                 sent_ts.add(response.get("ts"))
             except SlackApiError as e:
                 print(f"Error posting message: {e.response['error']}")
+            except genai.errors.APIError as e:
+                print(f"Gemini API error: {e.message}")
+            except Exception as e:
+                print(f"Unexpected error: {e}")
         return
 
     if event_type == "app_mention" and event.get("client_msg_id") not in processed_ids:
         if user == BOT_USER_ID:
             return
         try:
-            gemini = model.generate_content(event["text"])
+            gemini = genai_client.models.generate_content(
+                model=model_name,
+                contents=event["text"],
+            )
             textout = gemini.text.replace("**", "*")
             response = client.chat_postMessage(
                 channel=event["channel"],
@@ -94,6 +108,10 @@ def handle_event(data):
             processed_ids.add(event.get("client_msg_id"))
         except SlackApiError as e:
             print(f"Error posting message: {e.response['error']}")
+        except genai.errors.APIError as e:
+            print(f"Gemini API error: {e.message}")
+        except Exception as e:
+            print(f"Unexpected error: {e}")
         return
 
     # Si quieres manejar assistant_thread_context_changed, aquí va el código
@@ -103,8 +121,16 @@ def handle_event_async(data):
 
 @app.route('/gemini', methods=['GET'])
 def helloworld():
-    gemini = model.generate_content("Hi")
-    return gemini.text
+    try:
+        gemini = genai_client.models.generate_content(
+            model=model_name,
+            contents="Hi",
+        )
+        return gemini.text
+    except genai.errors.APIError as e:
+        return f"Gemini API error: {e.message}", 500
+    except Exception as e:
+        return f"Unexpected error: {e}", 500
 
 @app.route("/", methods=["POST"])
 def slack_events():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 Flask==3.0.3
 slack_sdk==3.26.2
 python-dotenv==1.0.1
-google-generativeai==0.8.5
+google-genai==1.27.0
 gunicorn==21.2.0
+pytest==8.2.0
+pytest-mock==3.14.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,33 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault('SLACK_BOT_TOKEN', 'test-token')
+os.environ.setdefault('GEMINI_API_KEY', 'test-key')
+import main
+
+
+def test_helloworld(mocker):
+    mocker.patch.object(main.genai_client.models, 'generate_content', return_value=mocker.Mock(text='hi'))
+    client = main.app.test_client()
+    resp = client.get('/gemini')
+    assert resp.status_code == 200
+    assert resp.data.decode() == 'hi'
+
+
+def test_handle_event_app_mention(mocker):
+    mocker.patch.object(main.genai_client.models, 'generate_content', return_value=mocker.Mock(text='reply'))
+    post = mocker.patch.object(main.client, 'chat_postMessage', return_value={'ts': '1'})
+    data = {
+        'event': {
+            'type': 'app_mention',
+            'client_msg_id': '123',
+            'channel': 'C',
+            'text': 'hello',
+            'ts': '1.23',
+            'user': 'U1'
+        }
+    }
+    main.BOT_USER_ID = 'B'
+    main.handle_event(data)
+    post.assert_called_once()
+


### PR DESCRIPTION
## Summary
- switch from `google-generativeai` to `google-genai`
- add runtime checks for required environment variables
- add error handling for Gemini API failures
- add pytest-based unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886f9ab323883258eadfb4f4a3ce24d