### PR TITLE
Add Slack profile fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ python main.py
 
 Set the environment variables `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, and `GEMINI_API_KEY` before running the application. Optionally define `BOT_USER_ID` with the identifier of your Slack bot user so the application can avoid replying to its own messages. If `BOT_USER_ID` is not set, the bot will attempt to determine it using Slack's `auth.test` API method. The bot uses the `gemini-2.0-flash` model by default, but you can override this by setting `GEMINI_MODEL`.
 
+To greet users by name, you can provide a Google Sheet that maps Slack IDs to preferred names. The `Slack ID` column may contain IDs, `<@U123>` mentions, or team links—the bot will extract the user ID automatically. Set `MY_GOOGLE_CREDS` with your service account JSON and `SHEET_ID` with the sheet identifier. If these variables are not configured, the bot will fall back to the display name from the Slack profile.
+
 Slack verifies requests using the signing secret. Expose the `/` route via a tunnel (e.g. `ngrok`) and configure the resulting URL as the Slack event request URL.
 
 The bot keeps track of the timestamps of the messages it posts and ignores any events that contain those timestamps to avoid responding to itself.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,18 +16,72 @@ def test_helloworld(mocker):
 
 def test_handle_event_app_mention(mocker):
     mocker.patch.object(main.genai_client.models, 'generate_content', return_value=mocker.Mock(text='reply'))
-    post = mocker.patch.object(main.client, 'chat_postMessage', return_value={'ts': '1'})
+    post = mocker.patch.object(main.client, 'chat_postMessage', return_value={'ts': '2'})
     data = {
         'event': {
             'type': 'app_mention',
             'client_msg_id': '123',
             'channel': 'C',
             'text': 'hello',
-            'ts': '1.23',
+            'ts': '2.34',
             'user': 'U1'
         }
     }
     main.BOT_USER_ID = 'B'
     main.handle_event(data)
     post.assert_called_once()
+
+
+def test_dm_greets_with_slack_name(mocker):
+    mocker.patch.object(main, 'get_preferred_name', return_value=None)
+    mocker.patch.object(main.client, 'users_info', return_value={'user': {'profile': {'display_name': 'Alice'}}})
+    post = mocker.patch.object(main.client, 'chat_postMessage', return_value={'ts': '3'})
+    data = {
+        'event': {
+            'type': 'message',
+            'channel': 'D1',
+            'text': 'hello',
+            'ts': '2.34',
+            'user': 'U1'
+        }
+    }
+    main.BOT_USER_ID = 'B'
+    main.handle_event(data)
+    post.assert_called_once_with(channel='D1', text='Hola Alice, ¿cómo te puedo ayudar hoy?', mrkdwn=True, thread_ts='2.34')
+
+
+def test_normalize_slack_id():
+    assert main.normalize_slack_id('<@U1>') == 'U1'
+    assert main.normalize_slack_id('https://app.slack.com/team/U2') == 'U2'
+
+
+def test_get_preferred_name_from_sheet(mocker):
+    os.environ['MY_GOOGLE_CREDS'] = '{}'
+    os.environ['SHEET_ID'] = '1'
+    creds = mocker.patch.object(main.Credentials, 'from_service_account_info', return_value='c')
+    gclient = mocker.Mock()
+    sheet = mocker.Mock()
+    gclient.open_by_key.return_value = sheet
+    worksheet = mocker.Mock()
+    sheet.sheet1 = worksheet
+    worksheet.get_all_records.return_value = [{'Slack ID': '<@U3|bob>', 'Name (first)': 'Bob'}]
+    mocker.patch.object(main.gspread, 'authorize', return_value=gclient)
+    assert main.get_preferred_name('U3') == 'Bob'
+
+
+def test_dm_greets_with_preferred_name(mocker):
+    mocker.patch.object(main, 'get_preferred_name', return_value='Bob')
+    post = mocker.patch.object(main.client, 'chat_postMessage', return_value={'ts': '3'})
+    data = {
+        'event': {
+            'type': 'message',
+            'channel': 'D1',
+            'text': 'hello',
+            'ts': '3.45',
+            'user': 'U3'
+        }
+    }
+    main.BOT_USER_ID = 'B'
+    main.handle_event(data)
+    post.assert_called_once_with(channel='D1', text='Hola Bob, ¿cómo te puedo ayudar hoy?', mrkdwn=True, thread_ts='3.45')
 


### PR DESCRIPTION
## Summary
- fall back to Slack profile info when Google Sheet doesn't have a name
- document `MY_GOOGLE_CREDS` and `SHEET_ID` env vars as optional
- add test for personalized greeting using Slack profile name
- handle Slack IDs stored as mentions or links
- unit tests for Slack ID normalization and DM greeting with preferred name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68880e2b00dc83258679f6eec07336bd