### PR TITLE
Fix logger import

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import boltPkg from '@slack/bolt';
 const { App, ExpressReceiver } = boltPkg;
 import { generateContent } from '../agent/gemini.js';
+import logger from '../utils/logger.js';
 
 // Globals (equivalentes a sets y caches)
 export const processedIds = new Set();


### PR DESCRIPTION
## Summary
- import logger in app.js to avoid ReferenceError

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688902f090888325b45254c98c4cbd5e