### PR TITLE
Fix Slack ID resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "node index.js",
-    "test": "jest --passWithNoTests"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --passWithNoTests"
   },
   "dependencies": {
     "@google/generative-ai": "^0.17.1",

--- a/utils/slackUtils.js
+++ b/utils/slackUtils.js
@@ -1,7 +1,8 @@
-import { app } from '../src/app.js'; // app.client para API calls
+// getSlackName carga app solo cuando se usa para evitar requerir variables de entorno durante tests
 
 export function normalizeSlackId(value) {
   if (!value) return '';
+
   let v = String(value).trim();
 
   // <@U…|alias>
@@ -15,13 +16,14 @@ export function normalizeSlackId(value) {
     v = v.replace(/\/$/, '').split('/').pop();
   }
 
-  // 'T……-U……'
+  // 'T……-U……' (team-user)
   if (v.includes('-')) {
-    const [, right] = v.split('-', 2);
-    if (right.startsWith('U')) v = right;
+    const parts = v.split('-');
+    const right = parts[parts.length - 1];
+    if (right && right.startsWith('U')) v = right;
   }
 
-  // Toma desde 'U'
+  // Si viene 'T…… U……' o algo raro, toma desde la 'U…'
   const uPos = v.indexOf('U');
   if (uPos > 0) v = v.slice(uPos);
 
@@ -40,6 +42,7 @@ export function isTopLevelDm(event) {
 
 export async function getSlackName(slackId) {
   try {
+    const { app } = await import('../src/app.js');
     const { user } = await app.client.users.info({ user: slackId });
     const profile = user.profile || {};
     return profile.display_name || profile.real_name;

--- a/utils/slackUtils.test.js
+++ b/utils/slackUtils.test.js
@@ -1,0 +1,23 @@
+let normalizeSlackId;
+
+beforeAll(async () => {
+  ({ normalizeSlackId } = await import('./slackUtils.js'));
+});
+
+describe('normalizeSlackId', () => {
+  test('handles <@U...|alias>', () => {
+    expect(normalizeSlackId('<@U12345|alias>')).toBe('U12345');
+  });
+
+  test('handles URLs', () => {
+    expect(normalizeSlackId('https://example.com/team/U12345')).toBe('U12345');
+  });
+
+  test('handles team-user format', () => {
+    expect(normalizeSlackId('T05NRU10WAW-U05SSCWHSV7')).toBe('U05SSCWHSV7');
+  });
+
+  test('returns empty string for falsy input', () => {
+    expect(normalizeSlackId('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- rewrite slack ID normalization to better mimic the prior Python logic
- delay importing the Slack app in `getSlackName` so tests run without environment variables
- add Jest tests for `normalizeSlackId`
- allow Jest to run on ESM modules

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688906730aa0832586cf52e0726362d4