### PR TITLE
Fix Slack name resolution

### DIFF
--- a/utils/slackUtils.js
+++ b/utils/slackUtils.js
@@ -43,7 +43,6 @@ export function isTopLevelDm(event) {
 export async function getSlackName(slackId) {
   try {
     const { app } = await import('../src/app.js');
-codex/fix-nameresolution.js-functionality
     const sid = normalizeSlackId(slackId);
     const { user } = await app.client.users.info({ user: slackId });
     const profile = user.profile || {};


### PR DESCRIPTION
## Summary
- remove stray text from `getSlackName`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890f2eeda48325bb6183bbaafe6701